### PR TITLE
Use debian's new verbose apt source descriptor

### DIFF
--- a/discord-repo/discord.list
+++ b/discord-repo/discord.list
@@ -1,1 +1,5 @@
-deb https://palfrey.github.io/discord-apt/debian/ ./
+Types: deb
+URIs: https://palfrey.github.io/discord-apt/debian/
+Suites: ./
+Components: 
+Signed-By: /etc/apt/trusted.gpg.d/discord-apt.gpg.asc


### PR DESCRIPTION
The one-liner sources.list format is not longer supported as of debian trixie release (at least for me, maybe i'm just weird). this PR updates the sources.list.d entry to use the new format.